### PR TITLE
fix: 消除 R2 SSR 并发下 TOC 污染

### DIFF
--- a/R2-DEPLOY.md
+++ b/R2-DEPLOY.md
@@ -4,7 +4,7 @@
 
 ### 1. Cloudflare R2 桶
 - Dashboard → R2 → Create bucket → 名字 `songdaochuanshu-static`
-- Settings → Public access → 绑定你的域名 `blog-static.songdaochuanshu.com`
+- Settings → Public access → 绑定你的域名 `blog-static.openserve.cloud`
 - （或者先用 `xxx.r2.dev` 测试）
 
 ### 2. Cloudflare API Token
@@ -31,7 +31,7 @@ pnpm install
 | Build command | `npx nuxt build` |
 | Build output directory | `.output` ⚠️ 不是 `/dist` 了 |
 | Root directory | （留空） |
-| Environment variables | `NUXT_PUBLIC_R2_BASE` = `https://blog-static.songdaochuanshu.com` |
+| Environment variables | `NUXT_PUBLIC_R2_BASE` = `https://blog-static.openserve.cloud` |
 
 （如果你的域名是 `xxx.r2.dev`，把上面那个 URL 换掉）
 
@@ -83,13 +83,13 @@ pnpm run upload:r2
 A: 看下 Cloudflare Pages 部署日志，确认 `.output/_worker.js` 存在。环境变量 `NUXT_PUBLIC_R2_BASE` 没设的话会 fallback 到默认值。
 
 **Q: 文章页 404？**
-A: 用浏览器直接打开 `https://blog-static.songdaochuanshu.com/manifest.json`，看能不能看到 JSON。能看到说明 R2 通了；看不到说明 R2 没开 public access 或域名没绑好。
+A: 用浏览器直接打开 `https://blog-static.openserve.cloud/manifest.json`，看能不能看到 JSON。能看到说明 R2 通了；看不到说明 R2 没开 public access 或域名没绑好。
 
 **Q: 我本地怎么测？**
 A: 
 ```bash
 pnpm install
-export NUXT_PUBLIC_R2_BASE=https://blog-static.songdaochuanshu.com
+export NUXT_PUBLIC_R2_BASE=https://blog-static.openserve.cloud
 pnpm dev
 ```
 Dev server 会从 R2 拉真数据。

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -38,7 +38,7 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       // Cloudflare Pages 后台设置环境变量 NUXT_PUBLIC_R2_BASE 覆盖
-      r2Base: process.env.NUXT_PUBLIC_R2_BASE || "https://blog-static.songdaochuanshu.com",
+      r2Base: process.env.NUXT_PUBLIC_R2_BASE || "https://blog-static.openserve.cloud",
     },
   },
 

--- a/utils/r2.ts
+++ b/utils/r2.ts
@@ -9,7 +9,7 @@
  * 实际生产环境还可以加 Cloudflare Cache API 或 KV 持久化。
  */
 
-import { marked } from "marked"
+import { Marked } from "marked"
 
 export interface ManifestPost {
   path: string
@@ -47,13 +47,8 @@ export function getR2Base(): string {
   return (cfg.public.r2Base as string) || "https://blog-static.songdaochuanshu.com"
 }
 
-// ============ marked 配置 ============
-// heading id 用 slugify 逻辑加，TOC 收集 h2/h3
-const slugifyCache = new Map<string, string>()
-
+// ============ slugify ============
 function slugify(text: string): string {
-  const cached = slugifyCache.get(text)
-  if (cached) return cached
   const stripped = text
     .toLowerCase()
     .replace(/<[^>]+>/g, "")
@@ -61,27 +56,29 @@ function slugify(text: string): string {
     .trim()
     .replace(/\s+/g, "-")
     .slice(0, 80)
-  const final = stripped || "heading"
-  slugifyCache.set(text, final)
-  return final
+  return stripped || "heading"
 }
 
-// 给 heading 加 id，收集 TOC
-const tocCollector: TocLink[] = []
-marked.use({
-  gfm: true,
-  breaks: false,
-  renderer: {
-    heading(this: any, text: string, level: number, raw: string) {
-      if (level === 2 || level === 3) {
-        const id = slugify(raw || text)
-        tocCollector.push({ id, text: text.replace(/<[^>]+>/g, ""), depth: level })
-        return `<h${level} id="${id}">${text}</h${level}>\n`
-      }
-      return `<h${level}>${text}</h${level}>\n`
+// ============ 创建独立的 marked 实例（每次请求新建，避免并发污染） ============
+function createMarkedInstance(tocCollector: TocLink[]): Marked {
+  const instance = new Marked({
+    gfm: true,
+    breaks: false,
+  })
+  instance.use({
+    renderer: {
+      heading(this: any, text: string, level: number, raw: string) {
+        if (level === 2 || level === 3) {
+          const id = slugify(raw || text)
+          tocCollector.push({ id, text: text.replace(/<[^>]+>/g, ""), depth: level })
+          return `<h${level} id="${id}">${text}</h${level}>\n`
+        }
+        return `<h${level}>${text}</h${level}>\n`
+      },
     },
-  },
-})
+  })
+  return instance
+}
 
 // ============ manifest 缓存 ============
 let manifestCache: { data: Manifest; fetchedAt: number } | null = null
@@ -117,14 +114,15 @@ export async function getRenderedPost(pathOrKey: string, opts: { byPath?: boolea
     headers: { "Cache-Control": "no-cache" },
   })
 
-  // 清空 TOC，重新收集
-  tocCollector.length = 0
+  // 创建独立 marked 实例，TOC 完全隔离
+  const tocCollector: TocLink[] = []
+  const marked = createMarkedInstance(tocCollector)
   const html = await marked.parse(md)
 
   return {
     meta,
     html: html as string,
-    toc: tocCollector.slice(),
+    toc: tocCollector,
   }
 }
 

--- a/utils/r2.ts
+++ b/utils/r2.ts
@@ -44,7 +44,7 @@ export interface TocLink {
 // ============ 配置 ============
 export function getR2Base(): string {
   const cfg = useRuntimeConfig()
-  return (cfg.public.r2Base as string) || "https://blog-static.songdaochuanshu.com"
+  return (cfg.public.r2Base as string) || "https://blog-static.openserve.cloud"
 }
 
 // ============ slugify ============


### PR DESCRIPTION
## 问题

`utils/r2.ts` 使用了全局 `marked.use()` + 模块级 `tocCollector`，SSR 并发请求下不同文章的 TOC 会互相串。

## 修复

- 移除全局 `marked.use()`，改为 `new Marked()` 按请求创建独立实例
- 移除模块级 `tocCollector` 和 `slugifyCache`
- `slugify` 改为纯函数

## 影响

- `getRenderedPost()` 现在是真正并发安全的
- 每个请求的 TOC 完全隔离，不再互相污染